### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -21,6 +21,9 @@ jobs:
 
 name: Post Release
 
+permissions:
+  contents: read
+
 on:
   release:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/ElysiumOSS/enterprise-ai-recursive-web-scraper/security/code-scanning/17](https://github.com/ElysiumOSS/enterprise-ai-recursive-web-scraper/security/code-scanning/17)

To fix the problem, we need to explicitly specify a `permissions` block in the workflow. This limits the scope of what the workflow can access via the automatically provided `GITHUB_TOKEN`, helping adhere to the principle of least privilege. The fix should be applied at the workflow root (above the `jobs:` section in `.github/workflows/post-release.yml`). Given the apparent functionality—to comment on releases—the minimal safe configuration is `contents: read`, but if the release commenter action needs to write comments, then `issues: write` or another relevant write permission should also be granted. However, based on common usage and the actions listed, we will add the general safe minimal starting point, which is `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
